### PR TITLE
Removed Travis-CI status image on the big bundles list

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/bigList.html.twig
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/bigList.html.twig
@@ -13,13 +13,6 @@
             <ul class="details">
                 <li>{% trans %}bundles.list.by{% endtrans %} <a href="{{ path('user_show', {'name': bundle.username }) }}" class="owner">{{ bundle.username }}</a></li>
                 <li>{% trans %}bundles.list.lastCommit{% endtrans %} <span>{{ bundle.lastCommitAt|date('date_format'|trans) }}</span></li>
-                {% if bundle.usesTravisCi %}
-                <li class="info-travis">
-                    <a href="http://travis-ci.org/{{ bundle.username }}/{{ bundle.name }}">
-                        <img src="https://secure.travis-ci.org/{{ bundle.username }}/{{ bundle.name }}.png" alt="Travis CI"></img>
-                    </a>
-                 </li>
-                {% endif %}
             </ul>
         </div>
         <div class="img">


### PR DESCRIPTION
Too distracting
Let's keep it on details pages only
