### PR TITLE
Add a configuration key to activate/deactivate debug mode for rabbitmq

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -94,6 +94,7 @@ knp_disqus:
             cache:     s2b_disqus
 
 old_sound_rabbit_mq:
+    debug: %old_sound_rabbit_mq.debug%
     connections:
         default:
             host:      %old_sound_rabbit_mq.host%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -23,5 +23,6 @@ parameters:
     old_sound_rabbit_mq.user: "guest"
     old_sound_rabbit_mq.password: "guest"
     old_sound_rabbit_mq.vhost: "/"
+    old_sound_rabbit_mq.debug: %kernel.debug%
 
     kb_sitemap.base_url: http://knpbundles.com


### PR DESCRIPTION
A profiler has been added in the latest version of RabbitMQBundle, this is really convenient BUT it means the "need for a running rabbitmq server" is back. Fortunately, you can disable it with a simple "debug" configuration key. 
With this PR, all you'll have to do to desactivate the profiler is add 

```
old_sound_rabbit_mq.debug: false
```

in your parameters.yml file.
