### PR TITLE
Add date in launching consumer message

### DIFF
--- a/bin/launch-rabbit-consumers.sh
+++ b/bin/launch-rabbit-consumers.sh
@@ -7,6 +7,6 @@ TASK="/usr/bin/php /site/app/console rabbitmq:consumer update_bundle --env=prod 
 
 for (( i=${NB_LAUNCHED}; i<${NB_TASKS}; i++ ))
 do
-    echo "Launching a new consumer"
+    echo "$(date +%c) - Launching a new consumer"
     nohup $TASK &
 done


### PR DESCRIPTION
Really quick one! 
I've added the date in the message displayed when a consumer is started, it's hard to know when was the last time we started a consumer without the date.
