### PR TITLE
[RFC] comment out localized routing twig extension

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/config/twig.yml
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/config/twig.yml
@@ -1,10 +1,10 @@
 services:
-    twig.extension.knp.locale_routing:
-        class: Knp\Bundle\KnpBundlesBundle\Twig\Extension\LocaleRoutingTwigExtension
-        tags:
-            - { name: twig.extension }
-        arguments:
-            - @router
+#    twig.extension.knp.locale_routing:
+#        class: Knp\Bundle\KnpBundlesBundle\Twig\Extension\LocaleRoutingTwigExtension
+#        tags:
+#            - { name: twig.extension }
+#        arguments:
+#            - @router
     twig.extension.knp.flawored_markdown:
         class: Knp\Bundle\KnpBundlesBundle\Twig\Extension\FlaworedMarkdownTwigExtension
         tags:


### PR DESCRIPTION
this is realted to the following error:

```
[2012-06-30 12:56:00] request.CRITICAL: Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Unable to choose a translation fo
r "wczoraj|%count% dni temu" with locale "pl".") in "KnpBundlesBundle::layout.html.twig" at line 55. (uncaught exception) at app/cache/prod/classes.php line 8510 [] []
```

trello card: https://trello.com/card/500-page-on-registering-bundle/4ebe3f9e20925090f411f100/89
