### PR TITLE
[RFC] Feature/fix trends [addresses #159]

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Repository/BundleRepository.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Repository/BundleRepository.php
@@ -148,7 +148,7 @@ JOIN
     FROM score
     WHERE
       date = CURRENT_DATE
-      AND value >= 15
+      AND value >= 1
     ) endRange
   ON startRange.bundle_id = endRange.bundle_id
 SET trend1 = (endScore - startScore)

--- a/src/Knp/Bundle/KnpBundlesBundle/Tests/Repository/BundleRepositoryFunctionalTest.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Tests/Repository/BundleRepositoryFunctionalTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Knp\Bundle\KnpBundlesBundle\Tests\Repository;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Knp\Bundle\KnpBundlesBundle\Entity\User;
+use Knp\Bundle\KnpBundlesBundle\Entity\Bundle;
+
+class BundleRepositoryFunctionalTest extends WebTestCase
+{
+    private $em;
+    protected $bundleRepository;
+    protected $scoreRepository;
+    protected $bundle1;
+
+    public function setUp()
+    {
+        $kernel = static::createKernel();
+        $kernel->boot();
+        $this->em = $kernel->getContainer()->get('knp_bundles.entity_manager');
+
+        // initialize 3 bundles with 3 score entries each on Score table
+        $this->bundleRepository = $this->em->getRepository('KnpBundlesBundle:Bundle');
+        $this->scoreRepository = $this->em->getRepository('KnpBundlesBundle:Score');
+
+        $user = new User();
+        $user->setName('userExample');
+        $user->setScore(1);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $bundle1 = new Bundle('vendor/bundle1');
+        $bundle1->setDescription('not null description');
+        $bundle1->setUser($user);
+        $bundle1->setScore(1);
+        $score11 = $this->scoreRepository->setScore(new \DateTime('yesterday'), $bundle1, 16);
+        $score12 = $this->scoreRepository->setScore(new \DateTime('today'), $bundle1, 45);
+        $this->em->persist($score11);
+        $this->em->persist($score12);
+        $this->em->persist($bundle1);
+
+        $bundle2 = new Bundle('vendor/bundle2');
+        $bundle2->setDescription('not null description');
+        $bundle2->setUser($user);
+        $bundle2->setScore(2);
+        $score21 = $this->scoreRepository->setScore(new \DateTime('yesterday'), $bundle2, 16);
+        $score22 = $this->scoreRepository->setScore(new \DateTime('today'), $bundle2, 45);
+        $this->em->persist($score21);
+        $this->em->persist($score22);
+        $this->em->persist($bundle2);
+
+        $bundle3 = new Bundle('vendor/bundle3');
+        $bundle3->setDescription('not null description');
+        $bundle3->setUser($user);
+        $bundle3->setScore(3);
+        $score31 = $this->scoreRepository->setScore(new \DateTime('yesterday'), $bundle3, 16);
+        $score32 = $this->scoreRepository->setScore(new \DateTime('today'), $bundle3, 45);
+        $this->em->persist($score31);
+        $this->em->persist($score32);
+        $this->em->persist($bundle3);
+
+        $this->em->flush();
+    }
+
+    public function testUpdateTrends()
+    {
+        $this->em->getConnection()->beginTransaction();
+
+        $nbRows = $this->bundleRepository->updateTrends();
+        $this->assertEquals(3, $nbRows);
+
+        $this->em->getConnection()->commit();
+        $this->em->clear();
+        
+        $bundle1 = $this->bundleRepository->findOneBy(array('name' => 'bundle1'));
+
+        $this->assertEquals(29, $bundle1->getTrend1());
+    }
+}


### PR DESCRIPTION
@stof was perceiving very few bundles were being sorted by trending. Actually 0 lately in several months. The reason for this is that the threshold was set to 15 score on the previous date to be able to participate in the trend sorting, else all those looser bundles were being cut and reset to trend1=0. That is pretty harsh but alright if and only if imo we let all active bundles to participate.

Usually is the case that good bundles start small with big changes so we want to award these bundles the opportunity to show off for a night or so. After all that is what trend is for. For the next day if they don't keep improving to show off they will loose stage of course and give way to newer bundles.

Another thing is the scoring has to change dramatically each day, so if the bundle has a high score yet it is untouched or it is not awarded an increase of score (and here the point the score may be hard to get if all the big bumps up had already been awarded) then the trend is reset to 0 and the fallback sorting remains the score.

Conclusion/Explanation

So in the future if we click on trend and see the same sorting as High Score let it be no surprise, it just means that no bundle was trendy by definition. We should see bundles which have lower score first for a night even on top of high scored bundles when they earn the spot as we have discussed above.
