### PR TITLE
	Change MaxAge to SharedMaxAge so that ESI works correctly

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Controller/UserController.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Controller/UserController.php
@@ -29,7 +29,7 @@ class UserController extends BaseController
 
         // this is private cache (don't cache with shared proxy)
         $response->setPrivate();
-        
+
         return $response;
     }
 


### PR DESCRIPTION
Knpbundles uses ESI for the top user bar, so that it is cached differently from the rest of the page. Unfortunately this currently does not work and many times, after logging in, the top menu is rendered as when you are not logged in and viceversa and you need to reload the page to see the change of status. The problem arises because the main bundle listing controller sets max-age and according to the symfony docs (http://symfony.com/doc/master/book/http_cache.html#using-esi-in-symfony2 ):

_"Once you start using ESI, remember to always use the s-maxage directive instead of max-age. As the browser only ever receives the aggregated resource, it is not aware of the sub-components, and so it will obey the max-age directive and cache the entire page. And you don't want that."_

So, currently the browser caches the whole page and that is why you many times don´t see the login changes. What I did is change setMaxAge to setSharedMaxAge as the docs recommend. 
