### PR TITLE
Show symfony versions in popover instead of listing on page

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Github/Repo.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Github/Repo.php
@@ -249,12 +249,18 @@ class Repo
         foreach ($versionsArray as $version => $value) {
             foreach (array('symfony/framework-bundle', 'symfony/symfony') as $requirement) {
                 if (isset($value['require'][$requirement])) {
+                    // Skip `dev` packages, add only `dev-master`
+                    if (0 === strpos($version, 'dev-') && 'dev-master' != $version) {
+                        continue;
+                    }
                     $symfonyVersions[$version] = $value['require'][$requirement]; // array('master' => '>=2.0,<2.2-dev')
                 }
             }
         }
 
-        $bundle->setSymfonyVersions($symfonyVersions);
+        if (!empty($symfonyVersions)) {
+            $bundle->setSymfonyVersions($symfonyVersions);
+        }
 
         return true;
     }

--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/public/css/styles.css
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/public/css/styles.css
@@ -114,7 +114,7 @@ code, pre {
 .icon-symfony {
     display: inline-block;
     height: 18px;
-    width: 19px;
+    width: 17px;
     vertical-align: middle;
     background: url('../images/icon_symfony.png') no-repeat
 }
@@ -1162,12 +1162,8 @@ code, pre {
     font-weight: bold
 }
 
-.sidebar-bundle-info li .versions-table {
-    width: 215px;
-    margin: 0 0 3px 26px;
-    font-size: 11px;
-    line-height: 14px;
-    word-break: break-all
+.sidebar-bundle-info li .symfony-versions {
+    cursor: help
 }
 
 .sidebar-chart section {
@@ -1276,6 +1272,15 @@ code, pre {
     display: block;
     line-height: 12px;
     color: #999;
+}
+
+
+.versions-table {
+    width: 215px;
+    margin: 0;
+    font-size: 12px;
+    line-height: 15px;
+    word-break: break-all
 }
 
 

--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/public/js/main.js
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/public/js/main.js
@@ -10,6 +10,7 @@
     });
 
     $('.sidebar-users-list img,abbr').tooltip();
+    $('.symfony-versions').popover({trigger: 'hover'});
 
     $('#add-bundle-btn').bind('click', function(event) {
         var ul = $(this).parent().parent().parent(),

--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/translations/messages.en.yml
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/translations/messages.en.yml
@@ -74,7 +74,7 @@ bundles.show:
         travis: "Travis CI"
         github: "Github"
         users: "Nb of users:"
-        symfonyVersion: "Required Symfony version:"
+        symfonyVersion: "Required Symfony version"
         unknown: "unknown"
     score:
         title: "Score details"

--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/show.html.twig
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/show.html.twig
@@ -32,6 +32,25 @@
 </div>
 {%- endblock %}
 
+{% block symfony_versions %}
+{% spaceless %}
+<table class='versions-table'>
+    <thead>
+    <tr>
+        <th>Bundle</th><th>Symfony</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for key, version in bundle.symfonyVersions %}
+    <tr>
+        <td>{{ key }}</td><td>{{ version ? version : "bundles.show.infos.unknown"|trans }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endspaceless %}
+{% endblock %}
+
 {% block right %}
     <div class="sidebar-box sidebar-bundle-info">
         <hgroup>
@@ -48,21 +67,7 @@
                 {%- endif -%}
                 <li><i class="icon-chart"></i><strong>{% trans %}bundles.show.infos.score{% endtrans %}</strong> <a href="#score-details" data-toggle="tab">{{ bundle.score }}</a></li>
                 {%- if bundle.symfonyVersions|length > 0 -%}
-                <li><i class="icon-symfony"></i><strong>{% trans %}bundles.show.infos.symfonyVersion{% endtrans %}</strong>
-                    <table class="versions-table">
-                        <thead>
-                        <tr>
-                            <th>Bundle</th><th>Symfony</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for key, version in bundle.symfonyVersions %}
-                        <tr>
-                            <td>{{ key }}</td><td>{{ version ? version : "bundles.show.infos.unknown"|trans }}</td>
-                        </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                <li><i class="icon-symfony"></i><strong class="symfony-versions" data-placement="bottom" data-content="{{ block('symfony_versions') }}" data-title="{% trans %}bundles.show.infos.symfonyVersion{% endtrans %}:">{% trans %}bundles.show.infos.symfonyVersion{% endtrans %}</strong>
                 </li>
                 {%- endif -%}
                 <li><i class="icon-calendar"></i><strong>{% trans %}bundles.show.infos.created{% endtrans %}</strong> {{ bundle.createdAt|date('date_format'|trans) }}</li>
@@ -81,7 +86,7 @@
                 <li title="{% trans %}bundles.show.infos.travis{% endtrans %}">
                     <i class="icon-cogs"></i>
                     <a href="{{ bundle.travisUrl }}">
-                        <img src="https://secure.travis-ci.org/{{ bundle.username }}/{{ bundle.name }}.png" alt="Travis Build Status" />
+                        <img src="https://secure.travis-ci.org/{{ bundle.username }}/{{ bundle.name }}.png" alt="Travis Build Status" width="89" height="13">
                     </a>
                 </li>
                 {%- endif -%}


### PR DESCRIPTION
 Show symfony versions in popover instead of listing on page.

Change parsing to not add `dev-` packages if it's not `dev-master`.
