### PR TITLE
Fixed behat tests for new design

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Features/api/developerList.feature
+++ b/src/Knp/Bundle/KnpBundlesBundle/Features/api/developerList.feature
@@ -20,6 +20,12 @@ Feature:
       | cordoval12 |
       | cordoval13 |
       | cordoval14 |
+      | cordoval15 |
+      | cordoval16 |
+      | cordoval17 |
+      | cordoval18 |
+      | cordoval19 |
+      | cordoval20 |
     Given the site has following bundles:
       | username   | name        | description | lastCommitAt | score | trend1 |
       | cordoval1  | Test1Bundle | test desc   |-1 day        | 10    | 15     |
@@ -33,9 +39,15 @@ Feature:
       | cordoval9  | Test5Bundle | test desc   |-1 day        | 10    | 15     |
       | cordoval10 | User5Bundle | user desc   |-2 days       | 20    | 5      |
       | cordoval11 | Test6Bundle | test desc   |-1 day        | 10    | 15     |
-      | cordoval12 | User7Bundle | user desc   |-2 days       | 20    | 5      |
-      | cordoval13 | User7Bundle | user desc   |-2 days       | 20    | 5      |
+      | cordoval12 | User6Bundle | user desc   |-2 days       | 20    | 5      |
+      | cordoval13 | Test7Bundle | test desc   |-2 days       | 20    | 5      |
       | cordoval14 | User7Bundle | user desc   |-2 days       | 20    | 5      |
+      | cordoval15 | Test8Bundle | test desc   |-2 days       | 20    | 5      |
+      | cordoval16 | User8Bundle | user desc   |-1 day        | 10    | 15     |
+      | cordoval17 | Test9Bundle | test desc   |-2 days       | 20    | 5      |
+      | cordoval18 | User9Bundle | user desc   |-2 days       | 20    | 5      |
+      | cordoval19 | Test7Bundle | test desc   |-2 days       | 20    | 5      |
+      | cordoval20 | User7Bundle | user desc   |-2 days       | 20    | 5      |
 
   Scenario: Show first page of developers list
     When I send a GET request to "/developer?page=1&format=json"
@@ -47,7 +59,13 @@ Feature:
       | cordoval12 |
       | cordoval13 |
       | cordoval14 |
+      | cordoval15 |
+      | cordoval16 |
+      | cordoval17 |
+      | cordoval18 |
+      | cordoval19 |
       | cordoval2  |
+      | cordoval20 |
       | cordoval3  |
       | cordoval4  |
       | cordoval5  |

--- a/src/Knp/Bundle/KnpBundlesBundle/Features/bundleSearch.feature
+++ b/src/Knp/Bundle/KnpBundlesBundle/Features/bundleSearch.feature
@@ -57,7 +57,7 @@ Feature: Searching bundles
     When I go to "/"
     And I search for "lorem"
     Then I should be on "/search"
-    And I should see "Search 'lorem'"
+    And I should see "Looking for keyword \"lorem\""
     And I should see "No bundles found"
 
   Scenario: Searching by partial name is rather search by author
@@ -80,12 +80,12 @@ Feature: Searching bundles
     When I go to "/"
     And I search for "f"
     Then I should be on "/search"
-    And I should see "Search 'f'"
+    And I should see "Looking for keyword \"f\""
     And I should see "No bundles found"
 
   Scenario: Searching by partial name but partial name is too long
     When I go to "/"
     And I search for "FOSTwitterBootstrapLongAndSuperLongNameForABundleIsJustTooMuchBundle"
     Then I should be on "/search"
-    And I should see "Search 'FOSTwitterBootstrapLongAndSuperLongNameForABundleIsJustTooMuchBundle'"
+    And I should see "Looking for keyword \"FOSTwitterBootstrapLongAndSuperLongNameForABundleIsJustTooMuchBundle\""
     And I should see "No bundles found"


### PR DESCRIPTION
Fixed behat tests so that they pass for the new design. Basically, they have to take into account that the developers page now shows 18 users instead of 12 and that the Search results page now shows "Looking for keyword" instead of "Search"
