### PR TITLE
Adding bundles is not working!

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Controller/BundleController.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Controller/BundleController.php
@@ -18,6 +18,7 @@ use Pagerfanta\Adapter\SolariumAdapter;
 use Knp\Bundle\KnpBundlesBundle\Entity\Bundle;
 use Knp\Bundle\KnpBundlesBundle\Entity\User;
 use Knp\Menu\MenuItem;
+use Knp\Bundle\KnpBundlesBundle\Updater\Exception\UserNotFoundException;
 
 class BundleController extends BaseController
 {
@@ -189,8 +190,8 @@ class BundleController extends BaseController
         }
 
         if (!$error) {
-            $bundle = str_replace(array('http://github.com', 'https://github.com', '.git'), '', $bundle);
-            if (preg_match('/^[a-z0-9-]+\/[a-z0-9-\.]+$/i', trim($bundle, '/'))) {
+            $bundle = trim(str_replace(array('http://github.com', 'https://github.com', '.git'), '', $bundle), '/');
+            if (preg_match('/^[a-z0-9-]+\/[a-z0-9-\.]+$/i', $bundle)) {
                 list($username, $name) = explode('/', $bundle);
 
                 $url = $this->generateUrl('bundle_show', array('username' => $username, 'name' => $name));


### PR DESCRIPTION
If you try to add a new bundle, the page shows a message saying "Repository exist, validating data..." but it will not continue from there and the bundle is not added. This is because when the bundle name is parsed, it is incorrectly left with a trailing slash and all the following code does not work correctly.

Also, when this happened, the correct code to handle a UserNotFound exception was not executed because the correct exception had not been imported.

Fixed both issues.

I looked into creating a new test to catch this problem and I found out that there was an older test which tested adding bundles, but it was commented out. I looked into the test code and found that it used the old Oauth provider. I looked into changing it to use the new provider but I have never used the Hwi Oauth library and did not really know how to proceed. Mainly the main problem is logging in users programatically, I am not sure how to do it. It would be good to get this test working again.
