### PR TITLE
Fix Travis-CI activity, clean-up KeywordRepository and UpdateBundleConsumer

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Consumer/UpdateBundleConsumer.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Consumer/UpdateBundleConsumer.php
@@ -5,8 +5,9 @@ namespace Knp\Bundle\KnpBundlesBundle\Consumer;
 use Knp\Bundle\KnpBundlesBundle\Github\Repo;
 use Knp\Bundle\KnpBundlesBundle\Git;
 use Knp\Bundle\KnpBundlesBundle\Entity\Bundle;
-use Knp\Bundle\KnpBundlesBundle\Entity\Score;
+use Knp\Bundle\KnpBundlesBundle\Entity\Keyword;
 use Knp\Bundle\KnpBundlesBundle\Entity\Owner;
+use Knp\Bundle\KnpBundlesBundle\Entity\Score;
 use Knp\Bundle\KnpBundlesBundle\Indexer\SolrIndexer;
 use Knp\Bundle\KnpBundlesBundle\Manager\OwnerManager;
 use Knp\Bundle\KnpBundlesBundle\Travis\Travis;
@@ -132,7 +133,8 @@ class UpdateBundleConsumer implements ConsumerInterface
             $this->logger->info(sprintf('Retrieved bundle %s', $bundle->getName()));
         }
 
-        $scoreRepo = $this->em->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Score');
+        $keywordRepo = $this->em->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Keyword');
+        $scoreRepo   = $this->em->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Score');
         for ($i = 0; $i < self::MAX_GITHUB_TRIALS; $i++) {
             try {
                 if (!$this->githubRepoApi->update($bundle)) {
@@ -146,16 +148,8 @@ class UpdateBundleConsumer implements ConsumerInterface
                 $this->indexer->indexBundle($bundle);
 
                 $this->updateContributors($bundle);
-                $this->updateKeywords($bundle);
-
-                $score = $scoreRepo->findOneBy(array('date' => new \DateTime(), 'bundle' => $bundle->getId()));
-                if (!$score) {
-                    $score = new Score();
-                    $score->setBundle($bundle);
-                }
-                $score->setValue($bundle->getScore());
-                $this->em->persist($score);
-                $this->em->flush();
+                $this->updateKeywords($bundle, $keywordRepo);
+                $this->updateScore($bundle, $scoreRepo);
 
                 if ($bundle->getUsesTravisCi()) {
                     $this->travis->update($bundle);
@@ -191,25 +185,45 @@ class UpdateBundleConsumer implements ConsumerInterface
         $bundle->setContributors($contributors);
 
         if ($this->logger) {
-            $this->logger->info(sprintf('%d contributor(s) have been retrieved for bundle %s', sizeof($contributors), $bundle->getName()));
+            $this->logger->info(sprintf('%d contributor(s) have been retrieved for bundle %s', count($contributors), $bundle->getName()));
         }
     }
 
     /**
-     * Updates bundle keywords fetched from componser.json
+     * Updates bundle keywords fetched from composer.json
      *
      * @param Bundle $bundle
+     * @param object $repository
      */
-    private function updateKeywords(Bundle $bundle)
+    private function updateKeywords(Bundle $bundle, $repository)
     {
         $keywords = $this->githubRepoApi->fetchComposerKeywords($bundle);
-        $repository = $this->em->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Keyword');
-
-        foreach ($keywords as $keyword) {
-            $keyword = $repository->findOrCreateOne($keyword);
+        foreach ($keywords as $value) {
+            $keyword = $repository->findOneBy(array('value' => $value));
+            if (!$keyword) {
+                $keyword = new Keyword();
+                $keyword->setValue($value);
+            }
 
             $bundle->addKeyword($keyword);
         }
+    }
+
+    /**
+     * Updates bundle score
+     *
+     * @param Bundle $bundle
+     * @param object $repository
+     */
+    private function updateScore(Bundle $bundle, $repository)
+    {
+        $score = $repository->findOneBy(array('date' => new \DateTime(), 'bundle' => $bundle->getId()));
+        if (!$score) {
+            $score = new Score();
+            $score->setBundle($bundle);
+        }
+
+        $score->setValue($bundle->getScore());
     }
 
     /**

--- a/src/Knp/Bundle/KnpBundlesBundle/Entity/Bundle.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Entity/Bundle.php
@@ -144,7 +144,7 @@ class Bundle
     /**
      * Internal scores
      *
-     * @ORM\OneToMany(targetEntity="Score", mappedBy="bundle", fetch="EXTRA_LAZY")
+     * @ORM\OneToMany(targetEntity="Score", mappedBy="bundle", cascade={"persist"}, fetch="EXTRA_LAZY")
      *
      * @var Collection
      */

--- a/src/Knp/Bundle/KnpBundlesBundle/Features/Context/FeatureContext.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Features/Context/FeatureContext.php
@@ -255,13 +255,19 @@ class FeatureContext extends RawMinkContext implements KernelAwareInterface
     public function theBundlesHaveFollowingKeywords(TableNode $table)
     {
         $entityManager = $this->getEntityManager();
+        $repository = $entityManager->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Keyword');
 
         foreach ($table->getHash() as $row) {
             if (isset($this->bundles[$row['bundle']])) {
-                $bundle = $this->bundles[$row['bundle']];
-                $keyword = $entityManager->getRepository('Knp\Bundle\KnpBundlesBundle\Entity\Keyword')->findOrCreateOne($row['keyword']);
+                $bundle  = $this->bundles[$row['bundle']];
+                $keyword = $repository->findOneBy(array('value' => $row['keyword']));
+                if (!$keyword) {
+                    $keyword = new Entity\Keyword();
+                    $keyword->setValue($row['keyword']);
+                }
 
                 $bundle->addKeyword($keyword);
+
                 $entityManager->persist($bundle);
             }
         }

--- a/src/Knp/Bundle/KnpBundlesBundle/Repository/KeywordRepository.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Repository/KeywordRepository.php
@@ -2,26 +2,8 @@
 
 namespace Knp\Bundle\KnpBundlesBundle\Repository;
 
-use Knp\Bundle\KnpBundlesBundle\Entity\Keyword;
 use Doctrine\ORM\EntityRepository;
 
 class KeywordRepository extends EntityRepository
 {
-    /**
-     * Find keyword with given value or create new one
-     * 
-     * @return Keyword
-     */
-    public function findOrCreateOne($value)
-    {
-        $keyword = $this->findOneByValue($value);
-
-        if (!$keyword) {
-            $class = $this->getClassName();
-            $keyword = new $class;
-            $keyword->setValue($value);
-        }
-
-        return $keyword;
-    }
 }

--- a/src/Knp/Bundle/KnpBundlesBundle/Repository/ScoreRepository.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Repository/ScoreRepository.php
@@ -3,9 +3,6 @@
 namespace Knp\Bundle\KnpBundlesBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\NoResultException;
-use Knp\Bundle\KnpBundlesBundle\Entity\Bundle;
-use Knp\Bundle\KnpBundlesBundle\Entity\Score;
 
 /**
  * ScoreRepository

--- a/src/Knp/Bundle/KnpBundlesBundle/Tests/Travis/TravisTest.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Tests/Travis/TravisTest.php
@@ -17,12 +17,15 @@ class RepoTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldUpdateBundleForSuccessfulBuildStatus()
     {
-        $travis = $this->getTravis(array('last_build_status' => 0), 'KnpLabs/KnpBundles');
+        $travis = $this->getTravis(array('last_build_status' => 0, 'last_build_finished_at' => '2011-10-25T11:27:42Z'), 'KnpLabs/KnpBundles');
 
-        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus'));
+        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus', 'getUpdatedAt'));
         $bundle->expects($this->once())
             ->method('setTravisCiBuildStatus')
             ->with($this->isTrue());
+        $bundle->expects($this->once())
+            ->method('getUpdatedAt')
+            ->will($this->returnValue(new \DateTime()));
 
         $bundle->setOwnerName('KnpLabs');
         $bundle->setName('KnpBundles');
@@ -35,12 +38,15 @@ class RepoTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldUpdateBundleForFailureBuildStatus()
     {
-        $travis = $this->getTravis(array('last_build_status' => 1), 'KnpLabs/KnpBundles');
+        $travis = $this->getTravis(array('last_build_status' => 1, 'last_build_finished_at' => '2011-10-25T11:27:42Z'), 'KnpLabs/KnpBundles');
 
-        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus'));
+        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus', 'getUpdatedAt'));
         $bundle->expects($this->once())
             ->method('setTravisCiBuildStatus')
             ->with($this->isFalse());
+        $bundle->expects($this->once())
+            ->method('getUpdatedAt')
+            ->will($this->returnValue(new \DateTime()));
 
         $bundle->setOwnerName('KnpLabs');
         $bundle->setName('KnpBundles');
@@ -53,12 +59,15 @@ class RepoTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldUpdateBundleForUndefinedBuildStatus()
     {
-        $travis = $this->getTravis(array('last_build_status' => 777));
+        $travis = $this->getTravis(array('last_build_status' => 777, 'last_build_finished_at' => '2011-10-25T11:27:42Z'));
 
-        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus'));
+        $bundle = $this->getMock('Knp\Bundle\KnpBundlesBundle\Entity\Bundle', array('setTravisCiBuildStatus', 'getUpdatedAt'));
         $bundle->expects($this->once())
             ->method('setTravisCiBuildStatus')
             ->with($this->isNull());
+        $bundle->expects($this->once())
+            ->method('getUpdatedAt')
+            ->will($this->returnValue(new \DateTime()));
 
         $bundle->setOwnerName('KnpLabs');
         $bundle->setName('KnpBundles');


### PR DESCRIPTION
-  Log Travis-CI activity only when build is newer than date of last bundle update
-  Remove useless code from KeywordRepository
- Cleaned up a bit UpdateBundleConsumer
