### PR TITLE
Fixing css tabs borders in developers profile

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/public/css/styles.css
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/public/css/styles.css
@@ -801,7 +801,7 @@ code, pre {
     padding-bottom: 10px;
     padding-top: 10px;
     border-radius: 0;
-    border-width: 0 1px 1px 0;
+    border-width: 0 1px 0 0;
     border-color: #ddd;
     font-weight: bold
 }


### PR DESCRIPTION
Fixing that:
![profileKnpBundles](https://f.cloud.github.com/assets/77759/246877/bd46a7be-8ab3-11e2-9d01-f763368d2943.png)

Link : http://knpbundles.com/developer/000fff/profile
