### PR TITLE
Removed Travis image size

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/show.html.twig
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/views/Bundle/show.html.twig
@@ -124,7 +124,7 @@
                 <li title="{% trans %}bundles.show.infos.travis{% endtrans %}">
                     <i class="icon-cogs"></i>
                     <a href="{{ bundle.travisUrl }}">
-                        <img src="https://secure.travis-ci.org/{{ bundle.ownerName }}/{{ bundle.name }}.png" alt="Travis Build Status" width="89" height="13"/>
+                        <img src="https://secure.travis-ci.org/{{ bundle.ownerName }}/{{ bundle.name }}.png" alt="Travis Build Status">
                     </a>
                 </li>
                 {%- endif -%}


### PR DESCRIPTION
![ok](https://api.travis-ci.org/FriendsOfSymfony/FOSRestBundle.png?branch=master) (77x19)
![ko](https://api.travis-ci.org/KnpLabs/KnpBundles.png) (65x18)

There are different sizes. And 89x13 is not correct (and not pretty).
