### PR TITLE
wrapped to `try-catch` statement remote api call

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Github/Repo.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Github/Repo.php
@@ -274,9 +274,7 @@ class Repo
             try {
                 $file = $api->show($bundle->getOwnerName(), $bundle->getName(), 'Resources/meta/LICENSE');
                 $bundle->setLicense(base64_decode($file['content']));
-            } catch (RuntimeException $e) {
-
-            }
+            } catch (RuntimeException $e) {}
         }
 
         if (null === $onlyFiles || in_array('configuration', $onlyFiles)) {


### PR DESCRIPTION
Related to #365 

During update the license file code tries fetch LIC file from different locations, and gets 404 sometime.
So I wrapped remote api (GitHub :) ) to `try-catch`
