### PR TITLE
Updating github search query

### DIFF
--- a/src/Knp/Bundle/KnpBundlesBundle/Resources/config/finder.xml
+++ b/src/Knp/Bundle/KnpBundlesBundle/Resources/config/finder.xml
@@ -30,6 +30,7 @@
             <tag name="knp_bundles.finder" />
             <argument type="service" id="knp_bundles.github_client" />
             <argument>Bundle</argument>
+            <argument>Bundle watchers:>=10 stars:>=10 fork:only</argument>
             <argument>%knp_bundles.finder.limit%</argument>
         </service>
     </services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets | #306 |
| Doc PR |  |

Optimizing Github search query to retrieve original bundles and forked ones with more than 10 stars/watchers
