### PR TITLE
fix bundle update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "knplabs/knp-disqus-bundle": "dev-master",
         "knplabs/knp-time-bundle": "dev-master",
         "knplabs/knp-zend-cache-bundle": "dev-fix-knpbundles",
-        "knplabs/github-api": "1.2.*",
+        "knplabs/github-api": "~1.7",
         "avalanche123/imagine-bundle": "dev-master",
         "kriswallsmith/buzz": "0.7",
         "nelmio/solarium-bundle": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "045155a0ee797ec27798403ae41a2b54",
+    "content-hash": "74c7b8b32f203096b2ebdbc5b303a030",
     "packages": [
         {
             "name": "avalanche123/imagine-bundle",
@@ -1438,16 +1438,16 @@
         },
         {
             "name": "knplabs/github-api",
-            "version": "1.2.7",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
-                "reference": "39dc9b4be0378c57279aa693f597cda5deb97c8f"
+                "reference": "98d0bcd2c4c96a40ded9081f8f6289907f73823c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/39dc9b4be0378c57279aa693f597cda5deb97c8f",
-                "reference": "39dc9b4be0378c57279aa693f597cda5deb97c8f",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/98d0bcd2c4c96a40ded9081f8f6289907f73823c",
+                "reference": "98d0bcd2c4c96a40ded9081f8f6289907f73823c",
                 "shasum": ""
             },
             "require": {
@@ -1456,7 +1456,8 @@
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.0",
+                "sllh/php-cs-fixer-styleci-bridge": "~1.3"
             },
             "suggest": {
                 "knplabs/gaufrette": "Needed for optional Gaufrette cache"
@@ -1464,12 +1465,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Github\\": "lib/"
+                "psr-4": {
+                    "Github\\": "lib/Github/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1495,7 +1496,7 @@
                 "gist",
                 "github"
             ],
-            "time": "2014-07-31T23:03:14+00:00"
+            "time": "2016-07-26T08:49:38+00:00"
         },
         {
             "name": "knplabs/knp-disqus-bundle",
@@ -1833,6 +1834,9 @@
                 "knplabs",
                 "zend"
             ],
+            "support": {
+                "source": "https://github.com/NiR-/KnpZendCacheBundle/tree/fix-knpbundles"
+            },
             "time": "2018-03-06T12:06:11+00:00"
         },
         {

--- a/src/Knp/Bundle/KnpBundlesBundle/Entity/Bundle.php
+++ b/src/Knp/Bundle/KnpBundlesBundle/Entity/Bundle.php
@@ -460,7 +460,7 @@ class Bundle
      */
     public function getReadme()
     {
-        return $this->readme;
+        return base64_decode($this->readme);
     }
 
     /**
@@ -470,7 +470,7 @@ class Bundle
      */
     public function setReadme($readme)
     {
-        $this->readme = $readme;
+        $this->readme = base64_encode($readme);
     }
 
     /**


### PR DESCRIPTION
bundle update is broken because of hexadecimal characteres in a README
(or something like that).